### PR TITLE
fix url in lab30 for using p4merge with git

### DIFF
--- a/src/labs.txt
+++ b/src/labs.txt
@@ -1879,7 +1879,7 @@ h2. Advanced Merging
 
 p. git doesn't provide any graphical merge tools, but it will gladly
 work with any third party merge tool you wish to use.  See
-"http://onestepback.org/index.cgi/Tech/Git/UsingP4MergeWithGit.red":http://onestepback.org/index.cgi/Tech/Git/UsingP4MergeWithGit.red
+"http://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#External-Merge-and-Diff-Tools":http://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#External-Merge-and-Diff-Tools
 for a description of using the Perforce merge tool with git.
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
In the lab30, a tips is given for installing p4merge. But the link is dead.

> See http://onestepback.org/index.cgi/Tech/Git/UsingP4MergeWithGit.red for a description of using the Perforce merge tool with git.

The official git documentation gives a description to [use p4merge as a visual merge tool for git](http://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#External-Merge-and-Diff-Tools). I thought it will be a good idea to update the link.
