### PR TITLE
we want to track shared/master, doesn't we?

### DIFF
--- a/src/labs.txt
+++ b/src/labs.txt
@@ -2568,7 +2568,7 @@ p. Continue with...
 
 Execute:
 git remote add shared ../hello.git
-git branch --track shared master
+git branch --track shared shared/master
 git pull shared master
 cat README
 


### PR DESCRIPTION
I think the Lab 49 is not very clear about its intention. I attached a screenshot to see what it is about.

The commit I sent fix the command `$ git branch --track shared master` with `$ git branch --track shared shared/master` but there is no need to create a new branch set up to track remote branch master from shared nor to track local branch master if we `$ git pull shared master`.

What do you think about?

![screenshot from 2015-08-05 13 13 49](https://cloud.githubusercontent.com/assets/701648/9084430/f2621e74-3b73-11e5-9378-f6c6e8f49784.png)
