### PR TITLE
sanitize auto build path in sample text output

### DIFF
--- a/rakelib/run.rake
+++ b/rakelib/run.rake
@@ -14,7 +14,14 @@ module RunLabs
       @command_output = "$ #{command}"
     else
       output = `#{command.strip} 2>&1`
-      @command_output = "$ #{command}#{output}"
+      if output.include?(Dir.home)
+        auto_dir = Pathname.new(__FILE__).join('../../auto').to_s
+        jims_path = '/Users/jim/Downloads/git_tutorial/work'
+        jims_output = output.gsub(auto_dir, jims_path)
+        @command_output = "$ #{command}#{jims_output}"
+      else
+        @command_output = "$ #{command}#{output}"
+      end
       print output
     end
   end


### PR DESCRIPTION
It was brought to my attention that the build process results in
committing the project path of the person who built the site.

I chose to use `/Users/jim/Downloads/git_tutorial/work`

`/Users/jim` because the rest of the labs are written from the perspective
of Jim.

`Downloads/git_tutorial/` because Jim used a mac and that's the location
the zip file would likely end up after downloading the zip file from the
website.

And finally, the work directory is the directory that the labs expect
the user to create.

I believe this closes #6 