### PR TITLE
Remove advanced topics covered in the labs

### DIFF
--- a/src/labs.txt
+++ b/src/labs.txt
@@ -2620,9 +2620,6 @@ h1. Advanced / Future Topics
 
 p. Here are some topics you might want to research on your own:
 
-* Reverting Committed Changes
-* Cross OS Line Endings
-* Remote Servers
 * Protocols
 * SSH Setup
 * Remote Branch Management


### PR DESCRIPTION
Cross OS lines endings are covered in the intial configuration. The others are covered in individual labs.